### PR TITLE
support retina

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     var mbAttr = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
       '<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
       'Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    mbUrl = 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpandmbXliNDBjZWd2M2x6bDk3c2ZtOTkifQ._QA7i5Mpkd_m30IGElHziw';
+    mbUrl = 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}'+(L.Browser.retina?'@2x':'')+'.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpandmbXliNDBjZWd2M2x6bDk3c2ZtOTkifQ._QA7i5Mpkd_m30IGElHziw';
 
     var grayscale   = L.tileLayer(mbUrl, {id: 'mapbox.light', attribution: mbAttr}),
       streets  = L.tileLayer(mbUrl, {id: 'mapbox.streets',   attribution: mbAttr});


### PR DESCRIPTION
This will load a higher resolution map for screens that have a higher resolution.

before: 

<img width="1440" alt="screen shot 2016-07-10 at 12 24 30" src="https://cloud.githubusercontent.com/assets/6270048/16713000/774fc4f2-4699-11e6-8a93-6415b43fae13.png">

after: 

<img width="1440" alt="screen shot 2016-07-10 at 12 24 39" src="https://cloud.githubusercontent.com/assets/6270048/16713001/8359f65a-4699-11e6-9ff1-d753ff20cfa1.png">
